### PR TITLE
fix: add @ethersprojects dependencies to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     }
   ],
   "dependencies": {
+    "burner-provider": "^1.0.15"
+  },
+  "peerDependencies": {
     "@ethersproject/address": "^5.0.1",
     "@ethersproject/bignumber": "^5.0.1",
     "@ethersproject/constants": "^5.0.1",
     "@ethersproject/contracts": "^5.0.1",
     "@ethersproject/providers": "^5.0.2",
     "@ethersproject/units": "^5.0.1",
-    "burner-provider": "^1.0.15"
-  },
-  "peerDependencies": {
     "react": "^16.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR swaps all the @ethersprojects dependencies to be peer dependencies instead to avoid conflicts