### PR TITLE
Force ESM Loader in NodeJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A set of hooks to turbocharge buidling",
   "author": "Shravan Sunder<shravan.sunder.dev@gmail.com>",
   "repository": "https://github.com/scaffold-eth/eth-hooks.git",
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
I'm getting `SyntaxError: Cannot use import statement outside a module` when trying to import this module in NextJS 12.

This is because NodeJS is trying to load the module with commonjs loader.

So this PR changes package.json "type" field to "module" so that NodeJS uses ESM Loader for it.

See https://nodejs.org/docs/latest/api/packages.html#determining-module-system