### PR TITLE
Using leadingTrigger on useExchangeEthPrice

### DIFF
--- a/src/dapps/dex/useExchangeEthPrice.ts
+++ b/src/dapps/dex/useExchangeEthPrice.ts
@@ -38,7 +38,7 @@ export const useExchangeEthPrice = (
     void getPrice();
   }, [targetNetwork.price, mainnetProvider]);
 
-  useOnRepetition(pollPrice, { pollTime, provider: mainnetProvider });
+  useOnRepetition(pollPrice, { pollTime, leadingTrigger: mainnetProvider != null, provider: mainnetProvider });
 
   return price;
 };


### PR DESCRIPTION
Hey @ShravanSunder 

I tested this and it works. I can't think on any unexpected side effects, this just sets the `leadingTrigger` to true (when the provider is ready) to get an initial request on useOnRepetition (without having to wait "polltime").

Used != instead of !== to follow what you did in other hooks (e.g. useBalance)

Could you publish this to npm so we can fetch the new v2 version on scaffold-eth?

Thanks!