### PR TITLE
fix useOnRepetition hook to make calls when primitive values in args changes

### DIFF
--- a/src/useOnRepetition.ts
+++ b/src/useOnRepetition.ts
@@ -41,8 +41,9 @@ export const useOnRepetition = (
 ): void => {
   const polling = options?.pollTime && options.pollTime > 0;
   const leadingCall = useRef(true);
-  // created a strigified args to use for deps
+  // created a stringified args to use for deps
   const argDeps = JSON.stringify(args ?? []);
+  const argsPrimitivesValuesDeps = JSON.stringify(args?.filter((arg) => arg !== Object(arg)));
 
   // save the input function provided
   const callFunctionWithArgs = useCallback(() => {
@@ -103,4 +104,12 @@ export const useOnRepetition = (
       callFunctionWithArgs();
     }
   }, [options.leadingTrigger, callFunctionWithArgs]);
+
+  // call if the primitive value in args changes
+  useEffect(() => {
+    if (options.leadingTrigger && callFunctionWithArgs != null) {
+      callFunctionWithArgs();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [argsPrimitivesValuesDeps, options.leadingTrigger]);
 };


### PR DESCRIPTION
Hii @ShravanSunder 👋, 

### Context : 
We have been trying to decrease the number of rpc call on scaffold-eth [here](https://github.com/scaffold-eth/scaffold-eth/pull/896) and while testing found that there is some issue with `useOnRepetition` hook. 

### Issue : 

When you pass `pollTime` to `useBalance` hook which utilizes `useOnRepetition` hook, 
The balance is updated immediately when the app loads, and then after every `pollTime` which in our case is set to `30sec` .

**Current Behaviour** : 
The problem is when you connect your wallet/change your `address` it takes `30sec`(pollTime) to update the `balance`.
Live demo: https://nonchalant-joke.surge.sh/
more details on this conversation [here](https://github.com/scaffold-eth/scaffold-eth/pull/896#issuecomment-1265166247)

**Expected Behaviour** : 
When you connect the wallet/ the address state is updated, the `balance` corresponding to that `address` should be fetched immediately similar to when we load the app initially. 

### Proposed Solution : 
Added new `useEffect` in `useOnRepetition` hook which runs only when the `primitive` values in args change (making it more general). 

Live demo with applied changes: https://incredible-wrench.surge.sh/ 

### Test : 
To test first I found all the hooks which use `useOnRepetition` under the hood and can be broken in two ways  : 

**1) Hooks which calls `useOnRepetition` with less than or equal to 2 args (2 because the new changes only reacts to args which are passed after 2nd argument )**

- useExchangeEthPrice
- useBlocknumber
- useGasPrice
- useNonce
- useTokenBalance

Just to be sure I copied the `useExchangeEthPrice`(which calls `useOnRepetition` similar to others above) and tried using a customized `useOnRepetition` hook with new changes and seems to work fine.

**2) Hooks which calls `useOnRepetition` with more than 2 args**

- useBalance
- useContractReader

Tested them out both with new changes and seem to work well. The below test repo has hooks copied from `eth-hooks` but they uses new `useOnRepetition`.
test repo : https://github.com/technophile-04/scaffold-eth/tree/rpc-test-2/packages/react-app/src/hooks
Live demo: https://incredible-wrench.surge.sh/  

Thanks to @carletex  for helping me out with this 🙌

PS : we tried many alternatives but this seems to be best feasible, minimal, and has close to no sideEffects on others. 

Thanks 🙏
