### PR TITLE
docs: fix typos

### DIFF
--- a/packages/docusaurus/docs/api/classes/EthersAppContext.EthersModalConnector.md
+++ b/packages/docusaurus/docs/api/classes/EthersAppContext.EthersModalConnector.md
@@ -211,7 +211,7 @@ Inherits from AbstractConnector.  This activates web3Modal and opens the modal.
 Once the user selects a provider
 - this will activate the provider and attach the appropriate event listeners.
 - get the account and signer
-- gets the ethers compatable provider
+- gets the ethers compatible provider
 
 ##### ⚠️ Errors
 - [UserClosedModalError](EthersAppContext.UserClosedModalError.md)

--- a/packages/docusaurus/docs/api/interfaces/Models.IEthersContext.md
+++ b/packages/docusaurus/docs/api/interfaces/Models.IEthersContext.md
@@ -9,7 +9,7 @@ custom_edit_url: null
 
 #### Summary
 The return type of [TCreateEthersModalConnector](../modules/Models.md#tcreateethersmodalconnector)
-- ethers compatable provider [TEthersProvider](../modules/Models.md#tethersprovider)
+- ethers compatible provider [TEthersProvider](../modules/Models.md#tethersprovider)
 - a callback to change the current signer
 - the current account, chainId and signer
 - callbacks to open the web3Modal, logout or change theme

--- a/packages/docusaurus/docs/api/modules/ContractAppContext.md
+++ b/packages/docusaurus/docs/api/modules/ContractAppContext.md
@@ -6,7 +6,7 @@ sidebar_position: 0
 custom_edit_url: null
 ---
 
-A context for your react app with [contractsContextFactory](ContractAppContext.md#contractscontextfactory) that provides you access to load, connect and use typed contracts throught your app.
+A context for your react app with [contractsContextFactory](ContractAppContext.md#contractscontextfactory) that provides you access to load, connect and use typed contracts through your app.
 
 See [the ContractAppContext docs](../../main/context/ContractAppContext) for detailed explanation and examples.
 

--- a/packages/docusaurus/docs/api/modules/EthersAppContext.md
+++ b/packages/docusaurus/docs/api/modules/EthersAppContext.md
@@ -35,7 +35,7 @@ This provider would be the one selected by using [EthersModalConnector](../class
 
 ##### ✨ Features
 Gives you access to consistent interface to get the current provider information [EthersModalConnector](../classes/EthersAppContext.EthersModalConnector.md)
-- ethers compatable provider TEthersProvider
+- ethers compatible provider TEthersProvider
 - a callback to change the current account (signer)
 - the current account, chainId and signer
 - callbacks to open the web3Modal, logout or change theme
@@ -69,7 +69,7 @@ This provider would be the one selected by using [EthersModalConnector](../class
 
 ##### ✨ Features
 Gives you access to consistent interface to get the current provider information [EthersModalConnector](../classes/EthersAppContext.EthersModalConnector.md)
-- ethers compatable provider TEthersProvider
+- ethers compatible provider TEthersProvider
 - a callback to change the current account (signer)
 - the current account, chainId and signer
 - callbacks to open the web3Modal, logout or change theme
@@ -202,7 +202,7 @@ Props for context
 | `secondaryWeb3ReactRoot.contextKey` | `string` | - |
 | `secondaryWeb3ReactRoot.web3ReactRoot` | `JSX.Element` | - |
 | `disableDefaultQueryClientRoot?` | `boolean` | disables the local queryClientRoot and QueryClientProvider for react-query and allows you to use your own |
-| `customGetEthersAppProviderLibrary?` | [`TGetEthersAppProviderLibrary`](EthersAppContext.md#tgetethersappproviderlibrary) | if you want to pass in your own provider. Make sure it is compatable with ethers.js, see [TGetEthersAppProviderLibrary](EthersAppContext.md#tgetethersappproviderlibrary) for details |
+| `customGetEthersAppProviderLibrary?` | [`TGetEthersAppProviderLibrary`](EthersAppContext.md#tgetethersappproviderlibrary) | if you want to pass in your own provider. Make sure it is compatible with ethers.js, see [TGetEthersAppProviderLibrary](EthersAppContext.md#tgetethersappproviderlibrary) for details |
 
 #### Defined in
 

--- a/packages/docusaurus/docs/api/modules/Helpers.md
+++ b/packages/docusaurus/docs/api/modules/Helpers.md
@@ -45,7 +45,7 @@ ___
 ▸ **isEthersProvider**(`providerBase`): `boolean`
 
 #### Summary
-Is it a ethers compatable provider, used by EthersModalConnector and useEthersProvider
+Is it a ethers compatible provider, used by EthersModalConnector and useEthersProvider
 
 #### Parameters
 

--- a/packages/docusaurus/docs/main/hooks/useBlockNumber.mdx
+++ b/packages/docusaurus/docs/main/hooks/useBlockNumber.mdx
@@ -1,6 +1,6 @@
 # useBlockNumber
 
-Invoke a callback on every block or with a polling time. On block is the prefered method.
+Invoke a callback on every block or with a polling time. On block is the preferred method.
 
 > Returns the block number.
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `packages/docusaurus/docs/api/classes/EthersAppContext.EthersModalConnector.md`
1 typo in `packages/docusaurus/docs/api/interfaces/Models.IEthersContext.md`
1 typo in `packages/docusaurus/docs/api/modules/ContractAppContext.md`
3 typos in `packages/docusaurus/docs/api/modules/EthersAppContext.md`
1 typo in `packages/docusaurus/docs/api/modules/Helpers.md`
1 typo in `packages/docusaurus/docs/main/hooks/useBlockNumber.mdx`


Best!